### PR TITLE
Fix header crest placeholders

### DIFF
--- a/assets/logo-vses-crest.svg
+++ b/assets/logo-vses-crest.svg
@@ -1,1 +1,12 @@
-[PASTE THE VSES ROUND CREST SVG HERE]
+<svg xmlns="http://www.w3.org/2000/svg" width="320" height="320" viewBox="0 0 320 320" role="img" aria-label="VSES crest">
+  <defs>
+    <style>
+      .maroon{fill:#800000}
+      .gold{fill:#FBBF24}
+      .white{fill:#fff}
+      .txt{font-family:Inter,Arial,Helvetica,sans-serif;font-weight:700;fill:#fff}
+    </style>
+  </defs>
+  <circle cx="160" cy="160" r="150" class="maroon"/>
+  <text x="50%" y="52%" class="txt" font-size="70" text-anchor="middle" dominant-baseline="middle">VSES</text>
+</svg>

--- a/assets/logo-vses-shield.svg
+++ b/assets/logo-vses-shield.svg
@@ -1,1 +1,13 @@
-[PASTE THE VSES SHIELD CREST SVG HERE]
+<svg xmlns="http://www.w3.org/2000/svg" width="240" height="320" viewBox="0 0 240 320" role="img" aria-label="VSES shield">
+  <defs>
+    <style>
+      .maroon{fill:#800000}
+      .gold{fill:#FBBF24}
+      .white{fill:#fff}
+      .txt{font-family:Inter,Arial,Helvetica,sans-serif;font-weight:700;fill:#fff}
+    </style>
+  </defs>
+  <path class="maroon" d="M120 10L30 50v110c0 64 38 124 90 150 52-26 90-86 90-150V50z"/>
+  <path class="gold" d="M120 30l70 30v100c0 52-32 100-70 120-38-20-70-68-70-120V60z" opacity=".6"/>
+  <text x="50%" y="58%" class="txt" font-size="56" text-anchor="middle" dominant-baseline="middle">VSES</text>
+</svg>


### PR DESCRIPTION
## Summary
- replace the temporary VSES crest placeholder text with an inline SVG logo
- add a matching shield-style VSES SVG so both header logos display without broken icons

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2195a22c483299d4a393d38900ede